### PR TITLE
Allow render to PDF plus small change to get it to work on 0.4

### DIFF
--- a/src/render.jl
+++ b/src/render.jl
@@ -34,7 +34,18 @@ function setup_shape!(cr, spec, state, size, px)
 end
 
 function render(fn, obj::EulerObject, state::EulerState; verbose=0, px=500.0)
-	c = CairoSVGSurface(fn, px, px);
+	if isa(fn, AbstractString)
+		bn,ext = splitext(fn)
+		if ext == ".svg"
+			c = CairoSVGSurface(fn, px, px);
+		elseif ext ==".pdf"
+			c = CairoPDFSurface(fn, px, px);
+		else
+			throw(ArgumentError("Unable to render to output with extension $(ext)"))
+		end
+	else
+		c = CairoSVGSurface(fn, px, px);
+	end
 	cr = CairoContext(c);
 	set_line_width(cr, px / 200.0);
 	select_font_face(cr, "Sans", Cairo.FONT_SLANT_NORMAL,

--- a/src/states.jl
+++ b/src/states.jl
@@ -91,7 +91,7 @@ function make_euler_object(labels, counts, specs::Vector{EulerSpec}; sizesum = 1
 	eo
 end
 make_euler_object(labels, counts, spec::EulerSpec; q...) = 
-	make_euler_object(labels, counts, [deepcopy(x)::EulerSpec for x in repeated(spec, length(labels))]; q...)
+	make_euler_object(labels, counts, EulerSpec[deepcopy(spec)::EulerSpec for x in 1:length(labels)]; q...)
 
 function random_state(eo::EulerObject)
 	rand(eo.nparams) .* (eo.ub .- eo.lb) .+ eo.lb


### PR DESCRIPTION
I just came across this nifty tool and made a few changes to get it to integrate with my workflow. Mainly, I wanted to be able to render the output to a pdf file, but I also made a small change that prevented the package from working on Julia 0.4. 